### PR TITLE
Add CalculatorEngine

### DIFF
--- a/src/main/kotlin/com/calculator/demo/CalculatorEngine.kt
+++ b/src/main/kotlin/com/calculator/demo/CalculatorEngine.kt
@@ -1,0 +1,123 @@
+package com.calculator.demo
+
+import kotlin.math.pow
+
+class CalculatorEngine(private val input: String) {
+
+    private var pos = 0
+
+    private fun consumeWhitespace() {
+        while (pos < input.length && input[pos].isWhitespace()) {
+            pos++
+        }
+    }
+
+    private fun consume(expected: Char): Char {
+        consumeWhitespace()
+        if (pos < input.length && input[pos] == expected) {
+            pos++
+            return expected
+        } else if (pos < input.length) {
+            throw RuntimeException("Unexpected character '${input[pos]}' at position $pos. Expected '$expected'")
+        } else {
+            throw RuntimeException("Expected '$expected' but found end of input")
+        }
+    }
+
+    private fun parseNumber(): Double {
+        consumeWhitespace()
+        var negative = false
+        if (pos < input.length && input[pos] == '-') {
+            negative = true
+            pos++
+        }
+        var number = ""
+        while (pos < input.length && input[pos].isDigit()) {
+            number += input[pos]
+            pos++
+        }
+        if (pos < input.length && input[pos] == '.') {
+            pos++
+            var decimal = ""
+            while (pos < input.length && input[pos].isDigit()) {
+                decimal += input[pos]
+                pos++
+            }
+            number += ".$decimal"
+        }
+        if (number.isEmpty()) {
+            throw RuntimeException("Expected a number at position $pos")
+        }
+        val result = number.toDouble()
+        return if (negative) -result else result
+    }
+
+    private fun parseFactor(): Double {
+        consumeWhitespace()
+        var result: Double
+        if (pos < input.length && input[pos] == '(') {
+            consume('(')
+            result = parseExpression()
+            if (pos < input.length && input[pos] == ')') {
+                consume(')')
+            } else {
+                throw RuntimeException("Unbalanced parentheses at position $pos")
+            }
+        } else {
+            result = parseNumber()
+        }
+        while (true) {
+            consumeWhitespace()
+            if (pos < input.length && input[pos] == '^') {
+                consume('^')
+                result = result.pow(parseFactor())
+            } else {
+                break
+            }
+        }
+        return result
+    }
+
+    private fun parseTerm(): Double {
+        var result = parseFactor()
+        while (true) {
+            consumeWhitespace()
+            if (pos < input.length && input[pos] == '*') {
+                consume('*')
+                result *= parseFactor()
+            } else if (pos < input.length && input[pos] == '/') {
+                consume('/')
+                result /= parseFactor()
+            } else {
+                break
+            }
+        }
+        return result
+    }
+
+    private fun parseExpression(): Double {
+        var result = parseTerm()
+        while (true) {
+            consumeWhitespace()
+            if (pos < input.length && input[pos] == '+') {
+                consume('+')
+                result += parseTerm()
+            } else if (pos < input.length && input[pos] == '-') {
+                consume('-')
+                result -= parseTerm()
+            } else {
+                break
+            }
+        }
+        return result
+    }
+
+    fun evaluate(): Double {
+        val result = parseExpression()
+        consumeWhitespace()
+        if (pos < input.length) {
+            throw RuntimeException("Unexpected character '${input[pos]}' at position $pos")
+        }
+        return result
+    }
+}

--- a/src/test/kotlin/com/calculator/demo/CalculatorEngineTest.kt
+++ b/src/test/kotlin/com/calculator/demo/CalculatorEngineTest.kt
@@ -1,0 +1,61 @@
+package com.calculator.demo
+
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import kotlin.math.abs
+
+class CalculatorEngineTest {
+
+    private val eps = 1e-9
+
+    @Test
+    fun evaluateSimple() {
+        assertTrue(abs(CalculatorEngine("-2 + 3").evaluate() - 1) < eps)
+
+        assertTrue(abs(CalculatorEngine("2 + 3 * 4").evaluate() - 14) < eps)
+
+        assertTrue(abs(CalculatorEngine("2 + 3 * (4 + 1)").evaluate() - 17) < eps)
+
+        assertTrue(abs(CalculatorEngine("2 + 3 * 4 ^ 2").evaluate() - 50) < eps)
+    }
+
+    @Test
+    fun evaluateComplex() {
+        assertTrue(abs(CalculatorEngine("(12 + 22*7) / (33 + (12*3 -8)) * 3").evaluate() - 8.16393442623) < eps)
+
+        assertTrue(abs(CalculatorEngine("((10 - 8)^2 + 5 * (4 / 5))^(6 - 4)").evaluate() - 64) < eps)
+    }
+
+    @Test
+    fun evaluateTricky() {
+        assertTrue(abs(CalculatorEngine("0^0").evaluate() - 1) < eps)
+
+        assertTrue(CalculatorEngine("1 / 0").evaluate().isInfinite())
+
+        assertTrue(CalculatorEngine("2 ^ 100000").evaluate().isInfinite())
+
+        assertTrue(CalculatorEngine("0 / 0").evaluate().isNaN())
+    }
+
+    @Test
+    fun evaluateExceptions() {
+        try {
+            CalculatorEngine("2 + 3 * (4 + )").evaluate()
+        } catch (e: RuntimeException) {
+            e.message?.let { assertTrue(it.startsWith("Expected a number")) }
+        }
+
+        try {
+            CalculatorEngine("2 + 3 * (4 + 1").evaluate()
+        } catch (e: RuntimeException) {
+            e.message?.let { assertTrue(it.startsWith("Unbalanced parentheses")) }
+        }
+
+        try {
+            CalculatorEngine("2 + 3 * (4 + @)").evaluate()
+        } catch (e: RuntimeException) {
+            e.message?.let { assertTrue(it.startsWith("Expected a number")) }
+        }
+    }
+}


### PR DESCRIPTION
Implemented CalculatorEngine that supports `+, -, *, /, ^` for now. 
I did some local tests to check it. You can add Unit Tests if you think I missed something.
It has some exception cases: Invalid character, bracket mismatch and missing a number.
I decided not to make exceptions for cases like division by zero or overflow because it seems Kotlin's `Double` type already handles such cases