### PR TITLE
Fix/double rounding up

### DIFF
--- a/backend/src/main/kotlin/com/calculator/demo/CalculatorService.kt
+++ b/backend/src/main/kotlin/com/calculator/demo/CalculatorService.kt
@@ -10,7 +10,7 @@ class CalculatorService(
     fun calculate(request: CalculationRequest): String {
         try {
             val result = CalculatorEngine(request.expression).evaluate()
-            val roundedResult = DecimalFormat("#.######").format(result)
+            val roundedResult = DecimalFormat("#.#########").format(result)
             val status = "success"
             val calculationResult =
                 CalculationResult(

--- a/backend/src/main/kotlin/com/calculator/demo/CalculatorService.kt
+++ b/backend/src/main/kotlin/com/calculator/demo/CalculatorService.kt
@@ -1,32 +1,28 @@
 package com.calculator.demo
 
 import org.springframework.stereotype.Service
+import java.text.DecimalFormat
 
 @Service
 class CalculatorService(
     val repository: CalculationResultRepository,
 ) {
     fun calculate(request: CalculationRequest): String {
-        val expression = request.expression
-        var status: String = "success"
-        var result: Double = 0.0
-
         try {
-            result = CalculatorEngine(request.expression).evaluate()
+            val result = CalculatorEngine(request.expression).evaluate()
+            val roundedResult = DecimalFormat("#.######").format(result)
+            val status = "success"
+            val calculationResult =
+                CalculationResult(
+                    expression = request.expression,
+                    status = status,
+                    result = roundedResult,
+                )
+            repository.save(calculationResult)
+            return roundedResult
         } catch (e: Exception) {
-            status = "failed. " + e.message
+            throw e
         }
-
-        val calculationResult =
-            CalculationResult(
-                expression = expression,
-                status = status,
-                result = result,
-            )
-        repository.save(calculationResult)
-
-        result = CalculatorEngine(request.expression).evaluate()
-        return result.toString()
     }
 
     fun getCalculationById(id: Long): CalculationResult =

--- a/backend/src/main/kotlin/com/calculator/demo/Classes.kt
+++ b/backend/src/main/kotlin/com/calculator/demo/Classes.kt
@@ -18,5 +18,5 @@ data class CalculationResult(
     val id: Long? = null,
     val expression: String = "",
     val status: String = "",
-    val result: Double? = null,
+    val result: String? = null,
 )


### PR DESCRIPTION
1. Now numbers are rounded up to **9** digits. Now floating point arithmetic error should not show up. Also when our numbers are integers it removes unnecessary `.0`.

2. Also changed [CalculatorService.kt](https://github.com/sharkov63/spbu-se-0-calculator/blob/main/backend/src/main/kotlin/com/calculator/demo/CalculatorService.kt) structure. I think saving incorrect request in our calculation history is redundant. So no we can rethrow any exception without second evaluation.

Closes #19 


<img width="1509" alt="Screenshot 2024-09-24 at 17 48 09" src="https://github.com/user-attachments/assets/c4f3f506-20ef-46c5-8a73-0767b2c19c97">
